### PR TITLE
ENG-19808 mlxfwreset before reboot in SR-IOV operator

### DIFF
--- a/pkg/plugins/mellanox/mellanox_plugin.go
+++ b/pkg/plugins/mellanox/mellanox_plugin.go
@@ -92,56 +92,56 @@ func (p *MellanoxPlugin) OnNodeStateChange(new *sriovnetworkv1.SriovNetworkNodeS
 		return
 	}
 
-	// for _, ifaceSpec := range mellanoxNicsSpec {
-	// 	pciPrefix := mlx.GetPciAddressPrefix(ifaceSpec.PciAddress)
-	// 	// skip processed nics, help not running the same logic 2 times for dual port NICs
-	// 	if _, ok := processedNics[pciPrefix]; ok {
-	// 		continue
-	// 	}
-	// 	processedNics[pciPrefix] = true
-	// 	fwCurrent, fwNext, err := p.helpers.GetMlxNicFwData(ifaceSpec.PciAddress)
-	// 	if err != nil {
-	// 		return false, false, err
-	// 	}
+	for _, ifaceSpec := range mellanoxNicsSpec {
+		pciPrefix := mlx.GetPciAddressPrefix(ifaceSpec.PciAddress)
+		// skip processed nics, help not running the same logic 2 times for dual port NICs
+		if _, ok := processedNics[pciPrefix]; ok {
+			continue
+		}
+		processedNics[pciPrefix] = true
+		fwCurrent, fwNext, err := p.helpers.GetMlxNicFwData(ifaceSpec.PciAddress)
+		if err != nil {
+			return false, false, err
+		}
 
-	// 	// isDualPort := mlx.IsDualPort(ifaceSpec.PciAddress, mellanoxNicsStatus)
-	// 	// Attributes to change
-	// 	attrs := &mlx.MlxNic{TotalVfs: -1}
-	// 	var changeWithoutReboot bool
+		// isDualPort := mlx.IsDualPort(ifaceSpec.PciAddress, mellanoxNicsStatus)
+		// Attributes to change
+		attrs := &mlx.MlxNic{TotalVfs: -1}
+		var changeWithoutReboot bool
 
-	// 	// totalVfs, totalVfsNeedReboot, totalVfsChangeWithoutReboot := mlx.HandleTotalVfs(fwCurrent, fwNext, attrs, ifaceSpec, isDualPort, mellanoxNicsSpec)
-	// 	// sriovEnNeedReboot, sriovEnChangeWithoutReboot := mlx.HandleEnableSriov(totalVfs, fwCurrent, fwNext, attrs)
-	// 	// needReboot = totalVfsNeedReboot || sriovEnNeedReboot
-	// 	// changeWithoutReboot = totalVfsChangeWithoutReboot || sriovEnChangeWithoutReboot
-	// 	needReboot = false
-	// 	changeWithoutReboot = false
+		// totalVfs, totalVfsNeedReboot, totalVfsChangeWithoutReboot := mlx.HandleTotalVfs(fwCurrent, fwNext, attrs, ifaceSpec, isDualPort, mellanoxNicsSpec)
+		// sriovEnNeedReboot, sriovEnChangeWithoutReboot := mlx.HandleEnableSriov(totalVfs, fwCurrent, fwNext, attrs)
+		// needReboot = totalVfsNeedReboot || sriovEnNeedReboot
+		// changeWithoutReboot = totalVfsChangeWithoutReboot || sriovEnChangeWithoutReboot
+		needReboot = false
+		changeWithoutReboot = false
 
-	// 	needLinkChange, err := mlx.HandleLinkType(pciPrefix, fwCurrent, attrs, mellanoxNicsSpec, mellanoxNicsStatus)
-	// 	if err != nil {
-	// 		return false, false, err
-	// 	}
-	// 	needReboot = needReboot || needLinkChange
+		needLinkChange, err := mlx.HandleLinkType(pciPrefix, fwCurrent, attrs, mellanoxNicsSpec, mellanoxNicsStatus)
+		if err != nil {
+			return false, false, err
+		}
+		needReboot = needReboot || needLinkChange
 
-	// 	// no FW changes allowed when NIC is externally managed
-	// 	if ifaceSpec.ExternallyManaged {
-	// 		// if totalVfsNeedReboot || totalVfsChangeWithoutReboot {
-	// 		// 	return false, false, fmt.Errorf(
-	// 		// 		"interface %s required a change in the TotalVfs but the policy is externally managed failing: firmware TotalVf %d requested TotalVf %d",
-	// 		// 		ifaceSpec.PciAddress, fwCurrent.TotalVfs, totalVfs)
-	// 		// }
-	// 		if needLinkChange {
-	// 			return false, false, fmt.Errorf("change required for link type but the policy is externally managed, failing")
-	// 		}
-	// 	}
+		// no FW changes allowed when NIC is externally managed
+		if ifaceSpec.ExternallyManaged {
+			// if totalVfsNeedReboot || totalVfsChangeWithoutReboot {
+			// 	return false, false, fmt.Errorf(
+			// 		"interface %s required a change in the TotalVfs but the policy is externally managed failing: firmware TotalVf %d requested TotalVf %d",
+			// 		ifaceSpec.PciAddress, fwCurrent.TotalVfs, totalVfs)
+			// }
+			if needLinkChange {
+				return false, false, fmt.Errorf("change required for link type but the policy is externally managed, failing")
+			}
+		}
 
-	// 	if needReboot || changeWithoutReboot {
-	// 		attributesToChange[ifaceSpec.PciAddress] = *attrs
-	// 	}
+		if needReboot || changeWithoutReboot {
+			attributesToChange[ifaceSpec.PciAddress] = *attrs
+		}
 
-	// 	if needReboot {
-	// 		pciAddressesToReset = append(pciAddressesToReset, ifaceSpec.PciAddress)
-	// 	}
-	// }
+		if needReboot {
+			pciAddressesToReset = append(pciAddressesToReset, ifaceSpec.PciAddress)
+		}
+	}
 
 	// Set total VFs to 0 for mellanox interfaces with no spec
 	for pciPrefix, portsMap := range mellanoxNicsStatus {


### PR DESCRIPTION
Well, overall it seems like something wrong on the firmware level enabling the SR-IOV capability, from the kernel perspective things looks okay to me

I see in the sriov-network-operator there's an option to enable mstfwreset after mlxconfig change! I guess that's something that we can try leveraging:
https://github.com/openshift/sriov-network-operator/blob/79cb3c6ae721220754189300539a38c63e38e66c/pkg/plugins/mellanox/mellanox_plugin.go#L215

I think this is going to resolve the reboot loop we're getting when running config-daemon, and I'll try doing it tomorrow.
All paths so far goes to firmware, I don't think I'll find anything more in the kernel, tbh

Infra PR to enable featureGate - https://github.com/togethercomputer/infra/pull/4044