### PR TITLE
ENG-21048 - KernelArgIommuOn instead of KernelArgIommuPt (to enable ATS & ACS)

### DIFF
--- a/pkg/consts/constants.go
+++ b/pkg/consts/constants.go
@@ -131,6 +131,7 @@ const (
 	KernelArgPciRealloc       = "pci=realloc"
 	KernelArgIntelIommu       = "intel_iommu=on"
 	KernelArgIommuPt          = "iommu=pt"
+	KernelArgIommuOn          = "iommu=on"
 	KernelArgIommuPassthrough = "iommu.passthrough=1"
 	KernelArgRdmaShared       = "ib_core.netns_mode=1"
 	KernelArgRdmaExclusive    = "ib_core.netns_mode=0"

--- a/pkg/plugins/generic/generic_plugin.go
+++ b/pkg/plugins/generic/generic_plugin.go
@@ -121,7 +121,7 @@ func NewGenericPlugin(helpers helper.HostHelpersInterface, options ...Option) (p
 	desiredKernelArgs := KargStateMapType{
 		consts.KernelArgPciRealloc:       helpers.IsKernelArgsSet(kargs, consts.KernelArgPciRealloc),
 		consts.KernelArgIntelIommu:       helpers.IsKernelArgsSet(kargs, consts.KernelArgIntelIommu),
-		consts.KernelArgIommuPt:          helpers.IsKernelArgsSet(kargs, consts.KernelArgIommuPt),
+		consts.KernelArgIommuOn:          helpers.IsKernelArgsSet(kargs, consts.KernelArgIommuOn),
 		consts.KernelArgIommuPassthrough: helpers.IsKernelArgsSet(kargs, consts.KernelArgIommuPassthrough),
 		consts.KernelArgRdmaShared:       false,
 		consts.KernelArgRdmaExclusive:    false,
@@ -433,10 +433,10 @@ func (p *GenericPlugin) addVfioDesiredKernelArg(state *sriovnetworkv1.SriovNetwo
 	kernelArgFnByCPUVendor := map[hostTypes.CPUVendor]func(){
 		hostTypes.CPUVendorIntel: func() {
 			p.enableDesiredKernelArgs(consts.KernelArgIntelIommu)
-			p.enableDesiredKernelArgs(consts.KernelArgIommuPt)
+			p.enableDesiredKernelArgs(consts.KernelArgIommuOn)
 		},
 		hostTypes.CPUVendorAMD: func() {
-			p.enableDesiredKernelArgs(consts.KernelArgIommuPt)
+			p.enableDesiredKernelArgs(consts.KernelArgIommuOn)
 		},
 		hostTypes.CPUVendorARM: func() {
 			p.enableDesiredKernelArgs(consts.KernelArgIommuPassthrough)


### PR DESCRIPTION
KernelArgIommuOn instead of KernelArgIommuPt (to enable ATS on the PCI devices)

Otherwise SR-IOV will keep checking on kernel args and will be finding a mismatch, will try to update them and fail (grubby doesn't exists), will stuck in the reboot loop